### PR TITLE
load step library when serving from Web server

### DIFF
--- a/initializeJoint.js
+++ b/initializeJoint.js
@@ -55,7 +55,7 @@ let testBtnArray = [];
 let xhr = new XMLHttpRequest();
 let obj;
 let superObj = [];
-xhr.open("GET", "stepLibs/steps.json", true);
+xhr.open("GET", "steplibs/steps.json", true);
 xhr.responseType = "json";
 xhr.send();
 xhr.onload = function (e) {


### PR DESCRIPTION
The step library JSON could only be loaded on Windows where upper/lower case in file names is insignificant.